### PR TITLE
bind the 'thisArg' to the document event handler method ref

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ export default (options = {}) => ComposedComponent => {
       const escToClose = this.makeSureValue('escToClose');
       const clickToClose = this.makeSureValue('clickToClose');
 
-      const handle = document[method];
+      const handle = document[method].bind(document);
       if (escToClose) {
         handle('keydown', this.handleKeydown);
       }


### PR DESCRIPTION
Hey great library.  I was testing this out on IE 11 (specifically 11.0.9600.16384) and noticed an "invalid calling object" error was being thrown from the `handleListeners` method. This PR binds the document to the `thisArg` of the handler method ref - i.e. `document[handler]` which appears to resolve this. Thanks.